### PR TITLE
Suggested updates for XE16 and AppEngine udpates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 # Package Files #
 *.war
 *.ear
+/target

--- a/pom.xml
+++ b/pom.xml
@@ -26,17 +26,22 @@ limitations under the License.
 
   <dependencies>
     <!-- Java Google API Client Library -->
-    <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-mirror</artifactId>
-      <version>v1-rev26-1.17.0-rc</version>
-    </dependency>
+        <dependency>
+        	<groupId>com.google.apis</groupId>
+        	<artifactId>google-api-services-mirror</artifactId>
+        	<version>v1-rev46-1.18.0-rc</version>
+        </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.17.0-rc</version>
+      <version>1.18.0-rc</version>
     </dependency>
-
+    <!--  App Engine Library -->
+        <dependency>
+        	<groupId>com.google.api-client</groupId>
+        	<artifactId>google-api-client-appengine</artifactId>
+        	<version>1.18.0-rc</version>
+        </dependency>
     <!-- Jetty plugin dependencies -->
     <dependency>
       <groupId>org.mortbay.jetty</groupId>

--- a/src/main/java/com/google/glassware/AuthServlet.java
+++ b/src/main/java/com/google/glassware/AuthServlet.java
@@ -55,7 +55,7 @@ public class AuthServlet extends HttpServlet {
               .setRedirectUri(WebUtil.buildUrl(req, "/oauth2callback")).execute();
 
       // Extract the Google User ID from the ID token in the auth response
-      String userId = ((GoogleTokenResponse) tokenResponse).parseIdToken().getPayload().getUserId();
+      String userId = ((GoogleTokenResponse) tokenResponse).parseIdToken().getPayload().getSubject();
 
       LOG.info("Code exchange worked. User " + userId + " logged in.");
 

--- a/src/main/java/com/google/glassware/ListableMemoryCredentialStore.java
+++ b/src/main/java/com/google/glassware/ListableMemoryCredentialStore.java
@@ -30,6 +30,13 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @author Jenny Murphy - http://google.com/+JennyMurphy
  */
+
+/*
+ * This is no longer used.  The credential store is now using AppEngineDataStore and StoredCredential per latest App Engine API
+ */
+
+
+@Deprecated
 public class ListableMemoryCredentialStore implements CredentialStore {
 
   /**


### PR DESCRIPTION
There are a few issues in this sample code that I have cleaned up.
1. The AuthUtil was CredentialStore which is deprecated.  I've replaced it with StoredCredential and the AppEngineDataStore.  This enables deprecation of  ListableMemoryCredentialStore.java, though it should be retained for migration purposes.
2. The AuthServlet was calling payload.getUserId() which is no longer available and has been replaced with getSubject()
3. I've updated the api calls in the pom.xml to use the latest version of Google API and the Latest mirror api.  
4. I've added AuthUtil.installMirrorAccount.  This provides an example for GDK authentication via Mirror for apps.
