### PR TITLE
Bug/timeline-attachments

### DIFF
--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -110,11 +110,11 @@ limitations under the License.
                 if (timelineItem.getAttachments() != null) {
                   for (Attachment attachment : timelineItem.getAttachments()) {
                     if (MirrorClient.getAttachmentContentType(credential, timelineItem.getId(), attachment.getId()).startsWith("image")) { %>
-                <a href="<%= appBaseUrl + "attachmentproxy?attachment=" +
-                  attachment.getId() + "&timelineItem=" + timelineItem.getId() %>">
-                <img src="<%= appBaseUrl + "attachmentproxy?attachment=" +
-                  attachment.getId() + "&timelineItem=" + timelineItem.getId() %>">
-                  </a>
+	                <a href="<%= appBaseUrl + "attachmentproxy?attachment=" +
+	                	attachment.getId() + "&timelineItem=" + timelineItem.getId() %>">
+	                	<img src="<%= appBaseUrl + "attachmentproxy?attachment=" +
+	                  		attachment.getId() + "&timelineItem=" + timelineItem.getId() %>"/>
+                  	</a>
                 <%  } else { %>
                 <a href="<%= appBaseUrl + "attachmentproxy?attachment=" +
                   attachment.getId() + "&timelineItem=" + timelineItem.getId() %>">

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -110,8 +110,11 @@ limitations under the License.
                 if (timelineItem.getAttachments() != null) {
                   for (Attachment attachment : timelineItem.getAttachments()) {
                     if (MirrorClient.getAttachmentContentType(credential, timelineItem.getId(), attachment.getId()).startsWith("image")) { %>
+                <a href="<%= appBaseUrl + "attachmentproxy?attachment=" +
+                  attachment.getId() + "&timelineItem=" + timelineItem.getId() %>">
                 <img src="<%= appBaseUrl + "attachmentproxy?attachment=" +
                   attachment.getId() + "&timelineItem=" + timelineItem.getId() %>">
+                  </a>
                 <%  } else { %>
                 <a href="<%= appBaseUrl + "attachmentproxy?attachment=" +
                   attachment.getId() + "&timelineItem=" + timelineItem.getId() %>">

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -109,7 +109,7 @@ limitations under the License.
                 <%
                 if (timelineItem.getAttachments() != null) {
                   for (Attachment attachment : timelineItem.getAttachments()) {
-                    if (MirrorClient.getAttachmentContentType(credential, timelineItem.getId(), attachment.getId()).startsWith("")) { %>
+                    if (MirrorClient.getAttachmentContentType(credential, timelineItem.getId(), attachment.getId()).startsWith("image")) { %>
                 <img src="<%= appBaseUrl + "attachmentproxy?attachment=" +
                   attachment.getId() + "&timelineItem=" + timelineItem.getId() %>">
                 <%  } else { %>


### PR DESCRIPTION
If the Attachment is for example a video, it appears as a broken image.
The content type is being checked with a `startsWith("")`, when it is supposed to be `startsWith("image")`

Also made images clickable.
